### PR TITLE
Fix autoloading when package is used as dependency

### DIFF
--- a/bin/github-changelog-generator
+++ b/bin/github-changelog-generator
@@ -1,7 +1,14 @@
 #!/usr/bin/env php
 <?php
 
-require_once '../vendor/autoload.php';
+// development autoload.php file
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+
+// deployment autoload.php file
+} else if (file_exists(__DIR__ . '/../../../autoload.php')) {
+    require_once __DIR__ . '/../../../autoload.php';
+}
 
 // define CLI arguments
 $cli = new Commando\Command();


### PR DESCRIPTION
While using this as a dependency for another package, I realised that the 'github-changelog-generator' file in the bin directory wasn't loading Composer's 'autoload.php' file correctly. This fixes that.